### PR TITLE
conjugate updates work for FPT setting with and without blocking.

### DIFF
--- a/scripts/inference_fpt_without_blocking.jl
+++ b/scripts/inference_fpt_without_blocking.jl
@@ -62,8 +62,10 @@ saveIter=3*10^2
 tKernel = RandomWalk([3.0, 5.0, 0.7, 0.01, 0.5],
                      [false, false, false, false, true])
 priors = Priors((#MvNormal([0.0,0.0,0.0], diagm(0=>[1000.0, 1000.0, 1000.0])),
+                 MvNormal([0.0], diagm(0=>[1000.0])),
                  #ImproperPrior(),
-                 ImproperPrior(),))
+                 #ImproperPrior(),)
+                 ))
 𝔅 = NoBlocking()
 blockingParams = ([], 0.1, NoChangePt())
 changePt = NoChangePt()
@@ -86,9 +88,9 @@ start = time()
                                     Val((false, false, true, false, false)),
                                     ),
                          paramUpdt=true,
-                         updtType=(#ConjugateUpdt(),
+                         updtType=(ConjugateUpdt(),
                                    #MetropolisHastingsUpdt(),
-                                   MetropolisHastingsUpdt(),
+                                   #MetropolisHastingsUpdt(),
                                    ),
                          skipForSave=10^1,
                          blocking=𝔅,

--- a/src/mcmc.jl
+++ b/src/mcmc.jl
@@ -658,7 +658,7 @@ Update parameters
 see the definition of  updateParam!(…, ::MetropolisHastingsUpdt, …) for the
 explanation of the arguments.
 """
-function updateParam!(::PartObs, ::ConjugateUpdt, tKern, θ, ::UpdtIdx,
+function updateParam!(::ObsScheme, ::ConjugateUpdt, tKern, θ, ::UpdtIdx,
                       yPr, WW, Pᵒ, P, XXᵒ, XX, ll, priors, fpt, recomputeODEs;
                       solver::ST=Ralston3(), verbose=false,
                       it=NaN) where {ObsScheme <: AbstractObsScheme, ST, UpdtIdx}


### PR DESCRIPTION
There must be a mistake in the Metropolis-Hastings parameter update routine when blocking is used (or imputation routine with blocking---conjugate update does not utilise all steps that this routine is making)