### PR TITLE
Restructuring of the mcmc.jl file, bug fixes, readying paramUpdate! for parallelisation

### DIFF
--- a/scripts/inference_fpt_with_blocking.jl
+++ b/scripts/inference_fpt_with_blocking.jl
@@ -57,7 +57,7 @@ L = @SMatrix [1. 0.]
 Ls = [L for _ in P̃]
 Σs = [Σ for _ in P̃]
 τ(t₀,T) = (x) ->  t₀ + (x-t₀) * (2-(x-t₀)/(T-t₀))
-numSteps=3*10^3
+numSteps=1*10^5
 saveIter=3*10^2
 tKernel = RandomWalk([3.0, 5.0, 0.5, 0.01, 0.5],
                      [false, false, false, false, true])

--- a/scripts/inference_fpt_with_blocking.jl
+++ b/scripts/inference_fpt_with_blocking.jl
@@ -57,20 +57,22 @@ L = @SMatrix [1. 0.]
 Ls = [L for _ in P̃]
 Σs = [Σ for _ in P̃]
 τ(t₀,T) = (x) ->  t₀ + (x-t₀) * (2-(x-t₀)/(T-t₀))
-numSteps=3*10^2
+numSteps=3*10^3
 saveIter=3*10^2
 tKernel = RandomWalk([3.0, 5.0, 0.5, 0.01, 0.5],
                      [false, false, false, false, true])
 priors = Priors((#MvNormal([0.0,0.0,0.0], diagm(0=>[1000.0, 1000.0, 1000.0])),
-                 #ImproperPrior(),
-                 ImproperPrior(),))
+                 #MvNormal([0.0], diagm(0=>[1000.0])),
+                 ImproperPrior(),
+                 #ImproperPrior(),)
+                 ))
 𝔅 = ChequeredBlocking()
 blockingParams = (collect(1:length(obs)-2)[1:1:end], 10^(-7), SimpleChangePt(100))
 changePt = NoChangePt()
 x0Pr = KnownStartingPt(x0)
 #x0Pr = GsnStartingPt(x0, x0, @SMatrix [20. 0; 0 20.])
 warmUp=100
-typeof(x0)
+
 Random.seed!(4)
 start = time()
 (chain, accRateImp, accRateUpdt,
@@ -87,8 +89,8 @@ start = time()
                                     ),
                          paramUpdt=true,
                          updtType=(#ConjugateUpdt(),
-                                   #MetropolisHastingsUpdt(),
                                    MetropolisHastingsUpdt(),
+                                   #MetropolisHastingsUpdt(),
                                    ),
                          skipForSave=10^1,
                          blocking=𝔅,

--- a/scripts/inference_fpt_with_blocking.jl
+++ b/scripts/inference_fpt_with_blocking.jl
@@ -59,15 +59,15 @@ Ls = [L for _ in P̃]
 τ(t₀,T) = (x) ->  t₀ + (x-t₀) * (2-(x-t₀)/(T-t₀))
 numSteps=3*10^4
 saveIter=3*10^2
-tKernel = RandomWalk([3.0, 5.0, 4.0, 0.01, 0.5],
+tKernel = RandomWalk([3.0, 5.0, 1.0, 0.01, 0.5],
                      [false, false, false, false, true])
 priors = Priors((#MvNormal([0.0,0.0,0.0], diagm(0=>[1000.0, 1000.0, 1000.0])),
-                 MvNormal([0.0], diagm(0=>[1000.0])),
-                 #ImproperPrior(),
+                 #MvNormal([0.0], diagm(0=>[1000.0])),
+                 ImproperPrior(),
                  #ImproperPrior(),)
                  ))
 𝔅 = ChequeredBlocking()
-blockingParams = (collect(1:length(obs)-2)[1:1:end], 10^(-7), SimpleChangePt(100))
+blockingParams = (collect(1:length(obs)-2)[1:1:end], 10^(-10), SimpleChangePt(100))
 changePt = NoChangePt()
 x0Pr = KnownStartingPt(x0)
 #x0Pr = GsnStartingPt(x0, x0, @SMatrix [20. 0; 0 20.])
@@ -80,7 +80,7 @@ start = time()
                          P̃, Ls, Σs, numSteps, tKernel, priors, τ;
                          fpt=fpt,
                          ρ=0.99,
-                         dt=1/500,
+                         dt=1/5000,
                          saveIter=saveIter,
                          verbIter=10^2,
                          updtCoord=(#Val((true, true, true, false, false)),
@@ -88,8 +88,8 @@ start = time()
                                     Val((false, false, true, false, false)),
                                     ),
                          paramUpdt=true,
-                         updtType=(ConjugateUpdt(),
-                                   #MetropolisHastingsUpdt(),
+                         updtType=(#ConjugateUpdt(),
+                                   MetropolisHastingsUpdt(),
                                    #MetropolisHastingsUpdt(),
                                    ),
                          skipForSave=10^1,

--- a/scripts/inference_fpt_with_blocking.jl
+++ b/scripts/inference_fpt_with_blocking.jl
@@ -57,13 +57,13 @@ L = @SMatrix [1. 0.]
 Ls = [L for _ in P̃]
 Σs = [Σ for _ in P̃]
 τ(t₀,T) = (x) ->  t₀ + (x-t₀) * (2-(x-t₀)/(T-t₀))
-numSteps=1*10^5
+numSteps=3*10^4
 saveIter=3*10^2
-tKernel = RandomWalk([3.0, 5.0, 0.5, 0.01, 0.5],
+tKernel = RandomWalk([3.0, 5.0, 4.0, 0.01, 0.5],
                      [false, false, false, false, true])
 priors = Priors((#MvNormal([0.0,0.0,0.0], diagm(0=>[1000.0, 1000.0, 1000.0])),
-                 #MvNormal([0.0], diagm(0=>[1000.0])),
-                 ImproperPrior(),
+                 MvNormal([0.0], diagm(0=>[1000.0])),
+                 #ImproperPrior(),
                  #ImproperPrior(),)
                  ))
 𝔅 = ChequeredBlocking()
@@ -79,7 +79,7 @@ start = time()
     paths, time_) = mcmc(eltype(x0), fptOrPartObs, obs, obsTime, x0Pr, 0.0, P˟,
                          P̃, Ls, Σs, numSteps, tKernel, priors, τ;
                          fpt=fpt,
-                         ρ=0.95,
+                         ρ=0.99,
                          dt=1/500,
                          saveIter=saveIter,
                          verbIter=10^2,
@@ -88,8 +88,8 @@ start = time()
                                     Val((false, false, true, false, false)),
                                     ),
                          paramUpdt=true,
-                         updtType=(#ConjugateUpdt(),
-                                   MetropolisHastingsUpdt(),
+                         updtType=(ConjugateUpdt(),
+                                   #MetropolisHastingsUpdt(),
                                    #MetropolisHastingsUpdt(),
                                    ),
                          skipForSave=10^1,

--- a/scripts/inference_fpt_without_blocking.jl
+++ b/scripts/inference_fpt_without_blocking.jl
@@ -57,7 +57,7 @@ L = @SMatrix [1. 0.]
 Ls = [L for _ in P̃]
 Σs = [Σ for _ in P̃]
 τ(t₀,T) = (x) ->  t₀ + (x-t₀) * (2-(x-t₀)/(T-t₀))
-numSteps=1*10^5
+numSteps=1*10^4
 saveIter=3*10^3
 tKernel = RandomWalk([3.0, 5.0, 0.7, 0.01, 0.5],
                      [false, false, false, false, true])

--- a/scripts/inference_fpt_without_blocking.jl
+++ b/scripts/inference_fpt_without_blocking.jl
@@ -58,12 +58,12 @@ Ls = [L for _ in P̃]
 Σs = [Σ for _ in P̃]
 τ(t₀,T) = (x) ->  t₀ + (x-t₀) * (2-(x-t₀)/(T-t₀))
 numSteps=1*10^5
-saveIter=3*10^2
-tKernel = RandomWalk([3.0, 5.0, 0.1, 0.01, 0.5],
+saveIter=3*10^3
+tKernel = RandomWalk([3.0, 5.0, 0.5, 0.01, 0.5],
                      [false, false, false, false, true])
 priors = Priors((#MvNormal([0.0,0.0,0.0], diagm(0=>[1000.0, 1000.0, 1000.0])),
-                 MvNormal([0.0], diagm(0=>[1000.0])),
-                 #ImproperPrior(),
+                 ##MvNormal([0.0], diagm(0=>[1000.0])),
+                 ImproperPrior(),
                  #ImproperPrior(),)
                  ))
 𝔅 = NoBlocking()
@@ -79,7 +79,7 @@ start = time()
     paths, time_) = mcmc(eltype(x0), fptOrPartObs, obs, obsTime, x0Pr, 0.0, P˟,
                          P̃, Ls, Σs, numSteps, tKernel, priors, τ;
                          fpt=fpt,
-                         ρ=0.9999,
+                         ρ=0.997,
                          dt=1/500,
                          saveIter=saveIter,
                          verbIter=10^2,
@@ -88,8 +88,8 @@ start = time()
                                     Val((false, false, true, false, false)),
                                     ),
                          paramUpdt=true,
-                         updtType=(ConjugateUpdt(),
-                                   #MetropolisHastingsUpdt(),
+                         updtType=(#ConjugateUpdt(),
+                                   MetropolisHastingsUpdt(),
                                    #MetropolisHastingsUpdt(),
                                    ),
                          skipForSave=10^1,

--- a/scripts/inference_fpt_without_blocking.jl
+++ b/scripts/inference_fpt_without_blocking.jl
@@ -57,13 +57,13 @@ L = @SMatrix [1. 0.]
 Ls = [L for _ in P̃]
 Σs = [Σ for _ in P̃]
 τ(t₀,T) = (x) ->  t₀ + (x-t₀) * (2-(x-t₀)/(T-t₀))
-numSteps=1*10^4
-saveIter=3*10^2
+numSteps=1*10^5
+saveIter=3*10^3
 tKernel = RandomWalk([3.0, 5.0, 0.7, 0.01, 0.5],
                      [false, false, false, false, true])
 priors = Priors((#MvNormal([0.0,0.0,0.0], diagm(0=>[1000.0, 1000.0, 1000.0])),
-                 MvNormal([0.0], diagm(0=>[1000.0])),
-                 #ImproperPrior(),
+                 #MvNormal([0.0], diagm(0=>[1000.0])),
+                 ImproperPrior(),
                  #ImproperPrior(),)
                  ))
 𝔅 = NoBlocking()
@@ -88,8 +88,8 @@ start = time()
                                     Val((false, false, true, false, false)),
                                     ),
                          paramUpdt=true,
-                         updtType=(ConjugateUpdt(),
-                                   #MetropolisHastingsUpdt(),
+                         updtType=(#ConjugateUpdt(),
+                                   MetropolisHastingsUpdt(),
                                    #MetropolisHastingsUpdt(),
                                    ),
                          skipForSave=10^1,

--- a/scripts/inference_fpt_without_blocking.jl
+++ b/scripts/inference_fpt_without_blocking.jl
@@ -59,11 +59,11 @@ Ls = [L for _ in P̃]
 τ(t₀,T) = (x) ->  t₀ + (x-t₀) * (2-(x-t₀)/(T-t₀))
 numSteps=1*10^5
 saveIter=3*10^2
-tKernel = RandomWalk([3.0, 5.0, 0.7, 0.01, 0.5],
+tKernel = RandomWalk([3.0, 5.0, 0.1, 0.01, 0.5],
                      [false, false, false, false, true])
 priors = Priors((#MvNormal([0.0,0.0,0.0], diagm(0=>[1000.0, 1000.0, 1000.0])),
-                 #MvNormal([0.0], diagm(0=>[1000.0])),
-                 ImproperPrior(),
+                 MvNormal([0.0], diagm(0=>[1000.0])),
+                 #ImproperPrior(),
                  #ImproperPrior(),)
                  ))
 𝔅 = NoBlocking()
@@ -79,7 +79,7 @@ start = time()
     paths, time_) = mcmc(eltype(x0), fptOrPartObs, obs, obsTime, x0Pr, 0.0, P˟,
                          P̃, Ls, Σs, numSteps, tKernel, priors, τ;
                          fpt=fpt,
-                         ρ=0.997,
+                         ρ=0.9999,
                          dt=1/500,
                          saveIter=saveIter,
                          verbIter=10^2,
@@ -88,8 +88,8 @@ start = time()
                                     Val((false, false, true, false, false)),
                                     ),
                          paramUpdt=true,
-                         updtType=(#ConjugateUpdt(),
-                                   MetropolisHastingsUpdt(),
+                         updtType=(ConjugateUpdt(),
+                                   #MetropolisHastingsUpdt(),
                                    #MetropolisHastingsUpdt(),
                                    ),
                          skipForSave=10^1,

--- a/scripts/inference_fpt_without_blocking.jl
+++ b/scripts/inference_fpt_without_blocking.jl
@@ -57,8 +57,8 @@ L = @SMatrix [1. 0.]
 Ls = [L for _ in P̃]
 Σs = [Σ for _ in P̃]
 τ(t₀,T) = (x) ->  t₀ + (x-t₀) * (2-(x-t₀)/(T-t₀))
-numSteps=1*10^4
-saveIter=3*10^3
+numSteps=1*10^5
+saveIter=3*10^2
 tKernel = RandomWalk([3.0, 5.0, 0.7, 0.01, 0.5],
                      [false, false, false, false, true])
 priors = Priors((#MvNormal([0.0,0.0,0.0], diagm(0=>[1000.0, 1000.0, 1000.0])),
@@ -104,7 +104,7 @@ print("time elapsed: ", elapsed, "\n")
 print("imputation acceptance rate: ", accRateImp,
       ", parameter update acceptance rate: ", accRateUpdt)
 
-x0⁺, pathsToSave = transformMCMCOutput(x0, paths, saveIter; chain=chain,
+x0⁺, pathsToSave = transformMCMCOutput(x0, paths, saveIter; θ=θ₀,#chain=chain,
                                        numGibbsSteps=1,
                                        parametrisation=parametrisation,
                                        warmUp=warmUp)

--- a/scripts/inference_with_blocking.jl
+++ b/scripts/inference_with_blocking.jl
@@ -17,7 +17,7 @@ include(joinpath(SRC_DIR, "fitzHughNagumo.jl"))
 include(joinpath(SRC_DIR, "fitzHughNagumo_conjugateUpdt.jl"))
 
 
-include(joinpath(SRC_DIR, "starting_pt.jl"))
+
 include(joinpath(SRC_DIR, "types.jl"))
 include(joinpath(SRC_DIR, "vern7.jl"))
 #include(joinpath(SRC_DIR, "tsit5.jl"))
@@ -25,6 +25,7 @@ include(joinpath(SRC_DIR, "vern7.jl"))
 include(joinpath(SRC_DIR, "ralston3.jl"))
 include(joinpath(SRC_DIR, "priors.jl"))
 include(joinpath(SRC_DIR, "guid_prop_bridge.jl"))
+include(joinpath(SRC_DIR, "starting_pt.jl"))
 include(joinpath(SRC_DIR, "random_walk.jl"))
 include(joinpath(SRC_DIR, "blocking_schedule.jl"))
 include(joinpath(SRC_DIR, "mcmc.jl"))
@@ -78,7 +79,7 @@ start = time()
                          P̃, Ls, Σs, numSteps, tKernel, priors, τ;
                          fpt=fpt,
                          ρ=0.9,
-                         dt=1/10000,
+                         dt=1/1000,
                          saveIter=saveIter,
                          verbIter=10^2,
                          updtCoord=(Val((true, true, true, false, false)),
@@ -88,7 +89,7 @@ start = time()
                          updtType=(ConjugateUpdt(),
                                    MetropolisHastingsUpdt(),
                                    ),
-                         skipForSave=10^1,
+                         skipForSave=10^0,
                          blocking=𝔅,
                          blockingParams=blockingParams,
                          solver=Vern7(),

--- a/scripts/inference_without_blocking.jl
+++ b/scripts/inference_without_blocking.jl
@@ -57,7 +57,7 @@ L = @SMatrix [1. 0.]
 Ls = [L for _ in P̃]
 Σs = [Σ for _ in P̃]
 τ(t₀,T) = (x) ->  t₀ + (x-t₀) * (2-(x-t₀)/(T-t₀))
-numSteps=2*10^3
+numSteps=1*10^5
 saveIter=3*10^2
 tKernel = RandomWalk([3.0, 5.0, 5.0, 0.01, 0.5],
                      [false, false, false, false, true])
@@ -78,7 +78,7 @@ start = time()
                          P̃, Ls, Σs, numSteps, tKernel, priors, τ;
                          fpt=fpt,
                          ρ=0.975,
-                         dt=1/10000,
+                         dt=1/1000,
                          saveIter=saveIter,
                          verbIter=10^2,
                          updtCoord=(Val((true, true, true, false, false)),
@@ -90,7 +90,7 @@ start = time()
                                    #MetropolisHastingsUpdt(),
                                    MetropolisHastingsUpdt(),
                                    ),
-                         skipForSave=10^1,
+                         skipForSave=10^0,
                          blocking=𝔅,
                          blockingParams=blockingParams,
                          solver=Vern7(),
@@ -106,6 +106,8 @@ x0⁺, pathsToSave = transformMCMCOutput(x0, paths, saveIter; chain=chain,
                                        numGibbsSteps=2,
                                        parametrisation=parametrisation,
                                        warmUp=warmUp)
+chain
+
 
 df2 = savePathsToFile(pathsToSave, time_, joinpath(OUT_DIR, "sampled_paths.csv"))
 df3 = saveChainToFile(chain, joinpath(OUT_DIR, "chain.csv"))

--- a/src/auxiliary/transforms.jl
+++ b/src/auxiliary/transforms.jl
@@ -25,8 +25,8 @@ function transformMCMCOutput(x0, paths, saveIter; chain=nothing, θ=nothing,
         θs = [θ for i in 1:length(paths)]
     else
         @assert chain != nothing
-        θs = chain[[i-warmUp for i in warmUp+1:warmUp+length(chain)
-                    if i % saveIter == 0]]
+        N = Int64((length(chain)-1)/numGibbsSteps) + warmUp
+        θs = chain[[numGibbsSteps*(i-warmUp) for i in 1:N if (i % saveIter == 0) && i > warmUp ]]
     end
 
     if parametrisation == :regular

--- a/src/blocking_schedule.jl
+++ b/src/blocking_schedule.jl
@@ -71,6 +71,7 @@ Empty constructor.
 """
 struct ChequeredBlocking{TP,TWW,TXX} <: BlockingSchedule
     P::TP      # blocking workspace: diffusion law
+    Pᵒ::TP     # blocking workspace: diffusion law
     WW::TWW    # blocking workspace: accepted Wiener path
     WWᵒ::TWW   # blocking workspace: proposed Wiener path
     XX::TXX    # blocking workspace: accepted diffusion path
@@ -136,23 +137,23 @@ struct ChequeredBlocking{TP,TWW,TXX} <: BlockingSchedule
                  zeros(Int64, length(blocks[2])))
         props = (zeros(Int64, length(blocks[1])),
                  zeros(Int64, length(blocks[2])))
-        new{TP,TWW,TXX}(deepcopy(P), deepcopy(WW), deepcopy(WW), deepcopy(XX),
-                        deepcopy(XX), (LsA, LsB), vs, (ΣsA, ΣsB),
+        new{TP,TWW,TXX}(deepcopy(P), deepcopy(P), deepcopy(WW), deepcopy(WW),
+                        deepcopy(XX), deepcopy(XX), (LsA, LsB), vs, (ΣsA, ΣsB),
                         (knotsA, knotsB), blocks, 1, accpt, props,
                         (chpA, chpB))
     end
 
-    function ChequeredBlocking(𝔅::ChequeredBlocking{TP̃, TWW, TXX}, P::TP,
+    function ChequeredBlocking(𝔅::ChequeredBlocking{TP̃, TWW, TXX}, P::TP, Pᵒ::TP
                                idx::Int64) where {TP̃,TP,TWW,TXX}
-        new{TP,TWW,TXX}(P, 𝔅.WW, 𝔅.WWᵒ, 𝔅.XX, 𝔅.XXᵒ, 𝔅.Ls, 𝔅.vs, 𝔅.Σs,
+        new{TP,TWW,TXX}(P, Pᵒ, 𝔅.WW, 𝔅.WWᵒ, 𝔅.XX, 𝔅.XXᵒ, 𝔅.Ls, 𝔅.vs, 𝔅.Σs,
                         𝔅.knots, 𝔅.blocks, idx, 𝔅.accpt, 𝔅.props, 𝔅.changePts)
     end
 
     function ChequeredBlocking()
         new{Nothing, Nothing, Nothing}(nothing, nothing, nothing, nothing,
                                        nothing, nothing, nothing, nothing,
-                                       ([0],[0]),([[0]],[[0]]), 1, ([0],[0]),
-                                       ([0],[0]),
+                                       nothing, ([0],[0]),([[0]],[[0]]), 1,
+                                       ([0],[0]), ([0],[0]),
                                        ([NoChangePt()],[NoChangePt()])
                                        )
     end
@@ -186,8 +187,10 @@ function next(𝔅::ChequeredBlocking, XX, θ)
 
     P = [GuidPropBridge(𝔅.P[i], Ls[i], vs[i], Σs[i], chPts[i], θ)
                                             for (i,_) in enumerate(𝔅.P)]
+    Pᵒ = [GuidPropBridge(𝔅.Pᵒ[i], Ls[i], vs[i], Σs[i], chPts[i], θ)
+                                            for (i,_) in enumerate(𝔅.Pᵒ)]
 
-    ChequeredBlocking(𝔅, P, newIdx)
+    ChequeredBlocking(𝔅, P, Pᵒ, newIdx)
 end
 
 """

--- a/src/blocking_schedule.jl
+++ b/src/blocking_schedule.jl
@@ -143,7 +143,7 @@ struct ChequeredBlocking{TP,TWW,TXX} <: BlockingSchedule
                         (chpA, chpB))
     end
 
-    function ChequeredBlocking(𝔅::ChequeredBlocking{TP̃, TWW, TXX}, P::TP, Pᵒ::TP
+    function ChequeredBlocking(𝔅::ChequeredBlocking{TP̃, TWW, TXX}, P::TP, Pᵒ::TP,
                                idx::Int64) where {TP̃,TP,TWW,TXX}
         new{TP,TWW,TXX}(P, Pᵒ, 𝔅.WW, 𝔅.WWᵒ, 𝔅.XX, 𝔅.XXᵒ, 𝔅.Ls, 𝔅.vs, 𝔅.Σs,
                         𝔅.knots, 𝔅.blocks, idx, 𝔅.accpt, 𝔅.props, 𝔅.changePts)

--- a/src/fitzHughNagumo_conjugateUpdt.jl
+++ b/src/fitzHughNagumo_conjugateUpdt.jl
@@ -1,15 +1,14 @@
 using GaussianDistributions
 """
-    conjugateDraw(θ, XX, P, prior, ::updtIdx)
+    conjugateDraw(θ, XX, PT, prior, ::updtIdx)
 
 Draw from the full conditional distribution of the parameters whose indices are
 specified by the object `updtIdx`, conditionally on the path given in container
 `XX`, and conditionally on all other parameter values given in vector `θ`.
 """
-function conjugateDraw(θ, XX, P, prior, updtIdx)
+function conjugateDraw(θ, XX, PT, prior, updtIdx)
     μ = mustart(updtIdx)
     𝓦 = μ*μ'
-    PT = P[1].Target
     ϑ = SVector(thetaex(updtIdx, θ))
     μ, 𝓦 = _conjugateDraw(ϑ, μ, 𝓦, XX, PT, updtIdx)
 

--- a/src/mcmc.jl
+++ b/src/mcmc.jl
@@ -525,7 +525,7 @@ function impute!(::ObsScheme, 𝔅::NoBlocking, Wnr, yPr, WWᵒ, WW, XXᵒ, XX, 
     llᵒ = logpdf(yPrᵒ, yᵒ)
     llᵒ += pathLogLikhd(ObsScheme(), XXᵒ, P, 1:m, fpt)
     llᵒ += lobslikelihood(P[1], yᵒ)
-    
+
     printInfo(verbose, it, value(ll), value(llᵒ), "impute")
 
     if acceptSample(llᵒ-ll, verbose)
@@ -1114,8 +1114,9 @@ function mcmc(::Type{K}, ::ObsScheme, obs, obsTimes, yPr::StartingPtPrior, w,
                 accUpdtCounter[j] += 1*acc
                 updtStepCounter += 1
                 θchain[updtStepCounter] = copy(θ)
+                verbose && print("\n")
             end
-            verbose && print("\n------------------------------------------------",
+            verbose && print("------------------------------------------------",
                              "------\n")
         end
     end

--- a/src/mcmc.jl
+++ b/src/mcmc.jl
@@ -115,22 +115,12 @@ function checkSingleCoordFpt(XXᵒ, c, cidx, fpt)
     k = length(XXᵒ.yy)
     thrsd = XXᵒ.yy[end][c]
     renewed = fpt.autoRenewed[cidx]
-    # or use s = fpt.upCrossing[cidx] ? 1 : -1
-    if fpt.upCrossing[cidx]
-        for i in 1:k
-            if !renewed && XXᵒ.yy[i][c] <= fpt.reset[cidx]
-                renewed = true
-            elseif renewed && XXᵒ.yy[i][c] > thrsd + 0.000001 # prevents numerical issues
-                return false
-            end
-        end
-    else
-        for i in 1:k
-            if !renewed && XXᵒ.yy[i][c] >= fpt.reset[cidx]
-                renewed = true
-            elseif renewed && XXᵒ.yy[i][c] < thrsd - 0.000001 # prevents numerical issues
-                return false
-            end
+    s = fpt.upCrossing[cidx] ? 1 : -1
+    for i in 1:k
+        if !renewed && (s*XXᵒ.yy[i][c] <= s*fpt.reset[cidx])
+            renewed = true
+        elseif renewed && (s*XXᵒ.yy[i][c] > s*thrsd)
+            return false
         end
     end
     return renewed
@@ -537,6 +527,7 @@ function impute!(::ObsScheme, 𝔅::NoBlocking, Wnr, yPr, WWᵒ, WW, XXᵒ, XX, 
 end
 
 
+#NOTE deprecated
 """
     swapXX!(𝔅::ChequeredBlocking, XX)
 
@@ -548,7 +539,7 @@ function swapXX!(𝔅::BlockingSchedule, XX)
     end
 end
 
-
+#NOTE deprecated
 """
     swapXX!(𝔅::NoBlocking, XX)
 
@@ -587,6 +578,7 @@ Default contribution to log-likelihood from the startin point under blocking
 startPtLogPdf(::Any, yPr::StartingPtPrior, y) = 0.0
 
 
+#NOTE deprecated
 """
     impute!(::ObsScheme, 𝔅::ChequeredBlocking, Wnr, y, WWᵒ, WW, XXᵒ, XX, P, ll,
             fpt; ρ=0.0, verbose=false, it=NaN, headStart=false) where


### PR DESCRIPTION
One should keep in mind that for the `first passage time` setting the distances between observations are large. It appears that accumulation of error is quite severe when blocking is used in this setting and therefore much smaller discretisation step needs to be used.